### PR TITLE
Feature: Custom themes

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -18,16 +18,101 @@ const Home = () => {
     const [isDarkMode, setIsDarkMode] = useState(false);
     const [isGameboyTheme, setIsGameboyTheme] = useState(false);
     const [isHomeTheme, setIsHomeTheme] = useState(false);
+    const [theme, setTheme] = useState('');
 
     const toggleDarkMode = () => {
-      const newTheme = !isDarkMode;
+        const newTheme = !isDarkMode;
         setIsDarkMode(newTheme);
+        setIsHomeTheme(false);
+        setIsGameboyTheme(false);
         localStorage.setItem('isDarkMode', JSON.stringify(newTheme));
+        localStorage.setItem('isHomeMode', JSON.stringify(false));
+        localStorage.setItem('isGBMode', JSON.stringify(false));
+    };
+
+    const toggleHomeMode = () => {
+        const newTheme = !isHomeTheme;
+        setIsHomeTheme(newTheme);
+        localStorage.setItem('isHomeMode', JSON.stringify(newTheme));
+    };
+
+    const toggleGameboyMode = () => {
+        const newTheme = !isGameboyTheme;
+        setIsHomeTheme(newTheme);
+        localStorage.setItem('isGBMode', JSON.stringify(newTheme));
     };
 
     const handleTheme = () => {
         const theme = document.getElementById('themeSel').value;
-        switch (theme) {
+        handleThemeChange(theme);
+        // switch (theme) {
+        //     case 'dark':
+        //         toggleDarkMode();
+        //         // setIsDarkMode(true);
+        //         // setIsGameboyTheme(false);
+        //         // setIsHomeTheme(false);
+        //         break;
+        //     case 'gameboy':
+        //         toggleGameboyMode();
+        //         // setIsGameboyTheme(true);
+        //         // setIsDarkMode(false);
+        //         // setIsHomeTheme(false);
+        //         break;
+        //     case 'home':
+        //         toggleHomeMode();
+        //         // setIsHomeTheme(true);
+        //         // setIsDarkMode(false);
+        //         // setIsGameboyTheme(false);
+        //         break;
+        //     default:
+        //         toggleDarkMode();
+        //         break;
+        // }
+    };
+
+    useEffect(() => {
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme !== null) {
+            setTheme(savedTheme);
+        }
+    }, []);
+
+    const handleThemeChange = (newTheme) => {
+        setTheme(newTheme);
+        localStorage.setItem('theme', newTheme);
+    };
+
+useEffect(() => {
+    if (theme === 'dark') {
+        document.documentElement.classList.add('dark', 'bg-slate-900', 'text-slate-50');
+    } else {
+        document.documentElement.classList.remove('dark', 'bg-slate-900', 'text-slate-50');
+    } 
+}, [theme]);
+
+useEffect(() => {
+    if (theme === 'gameboy') {
+        document.documentElement.classList.add('gb', 'bg-gameboy-bg', 'text-gameboy-bg');
+    } else {
+        document.documentElement.classList.remove('gb', 'bg-gameboy-bg', 'text-gameboy-bg');
+    } 
+}, [theme]);
+
+useEffect(() => {
+    if (theme === 'home') {
+        document.documentElement.classList.add('home', 'bg-gradient-to-r', 'from-home-bg', 'via-home-midbg', 'to-home-endbg',  'text-home-text');
+    } else {
+        document.documentElement.classList.remove('home', 'bg-gradient-to-r', 'from-home-bg', 'via-home-midbg', 'to-home-endbg', 'text-home-text');
+    } 
+}, [theme]);
+
+    useEffect(() => {
+        fetchPokemons(setPokemons, setLoading, generation);
+    }, [generation]);
+
+    useEffect(() => {
+        const storedTheme = localStorage.getItem('theme');
+        switch (storedTheme) {
             case 'dark':
                 setIsDarkMode(true);
                 setIsGameboyTheme(false);
@@ -44,46 +129,21 @@ const Home = () => {
                 setIsGameboyTheme(false);
                 break;
             default:
-                setIsHomeTheme(false);
                 setIsDarkMode(false);
                 setIsGameboyTheme(false);
+                setIsHomeTheme(false);
                 break;
         }
-    };
-
-    useEffect(() => {
-        if (isDarkMode) {
-            document.documentElement.classList.add('dark', 'bg-slate-900', 'text-slate-50');
-          } else {
-            document.documentElement.classList.remove('dark', 'bg-slate-900', 'text-slate-50');
-          } 
-    }, [isDarkMode]);
-
-    useEffect(() => {
-        if (isGameboyTheme) {
-            document.documentElement.classList.add('gb', 'bg-gameboy-bg', 'text-gameboy-bg');
-          } else {
-            document.documentElement.classList.remove('gb', 'bg-gameboy-bg', 'text-gameboy-bg');
-          } 
-    }, [isGameboyTheme]);
-
-    useEffect(() => {
-        if (isHomeTheme) {
-            document.documentElement.classList.add('home', 'bg-gradient-to-r', 'from-home-bg', 'via-home-midbg', 'to-home-endbg',  'text-home-text');
-          } else {
-            document.documentElement.classList.remove('home', 'bg-gradient-to-r', 'from-home-bg', 'via-home-midbg', 'to-home-endbg', 'text-home-text');
-          } 
-    }, [isHomeTheme]);
-
-    useEffect(() => {
-        fetchPokemons(setPokemons, setLoading, generation);
-    }, [generation]);
-
-    useEffect(() => {
-        const storedTheme = localStorage.getItem('isDarkMode');
-        if (storedTheme) {
-          setIsDarkMode(JSON.parse(storedTheme));
-        }
+        // if( {
+        //     setIsDarkMode(JSON.parse(localStorage.getItem('isDarkMode')));
+        // } else if(localStorage.getItem('isGBMode')) {
+        //     setIsGameboyTheme(JSON.parse(localStorage.getItem('isGBMode')));
+        // } else if(localStorage.getItem('isHomeMode')) {
+        //     setIsHomeTheme(JSON.parse(localStorage.getItem('isHomeMode')));
+        // }
+        // if (storedTheme) {
+        //   setIsDarkMode(JSON.parse(storedTheme));
+        // }
       }, []);
 
     const filter = () => {
@@ -93,10 +153,10 @@ const Home = () => {
 
     return !loading ?
         <>
-            <div
-                className={
-                    `xl:px-24 px-10 mt-8 py-4 sticky top-0 dark:bg-slate-900  ${openPokemonInfo ? 'xl:pl-10 w-[70%] relative left-[30%]' : ''}`
-                }>
+<div
+    className={
+        `xl:px-24 px-10 mt-8 py-4 sticky top-0 dark:bg-slate-900  ${openPokemonInfo ? 'xl:pl-10 w-[70%] relative left-[30%]' : ''}`
+    }>
                 <input
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
@@ -118,9 +178,9 @@ const Home = () => {
                     />
                     <select id="themeSel" onChange={handleTheme} className='outline-none border-2 py-1 px-5 text-md rounded-full cursor-pointer dark:bg-slate-800 dark:text-slate-50'>
                         <option value="">Light</option>
-                        <option value="dark">Dark</option>
-                        <option value="gameboy">Gameboy</option>
-                        <option value="home">Pokemon Home</option>
+                        <option value="dark" selected={theme == "dark"}>Dark</option>
+                        <option value="gameboy" selected={theme == "gameboy"}>Gameboy</option>
+                        <option value="home" selected={theme == "home"}>Pokemon Home</option>
                     </select>
                 </div>
             </div>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -20,54 +20,9 @@ const Home = () => {
     const [isHomeTheme, setIsHomeTheme] = useState(false);
     const [theme, setTheme] = useState('');
 
-    const toggleDarkMode = () => {
-        const newTheme = !isDarkMode;
-        setIsDarkMode(newTheme);
-        setIsHomeTheme(false);
-        setIsGameboyTheme(false);
-        localStorage.setItem('isDarkMode', JSON.stringify(newTheme));
-        localStorage.setItem('isHomeMode', JSON.stringify(false));
-        localStorage.setItem('isGBMode', JSON.stringify(false));
-    };
-
-    const toggleHomeMode = () => {
-        const newTheme = !isHomeTheme;
-        setIsHomeTheme(newTheme);
-        localStorage.setItem('isHomeMode', JSON.stringify(newTheme));
-    };
-
-    const toggleGameboyMode = () => {
-        const newTheme = !isGameboyTheme;
-        setIsHomeTheme(newTheme);
-        localStorage.setItem('isGBMode', JSON.stringify(newTheme));
-    };
-
     const handleTheme = () => {
         const theme = document.getElementById('themeSel').value;
         handleThemeChange(theme);
-        // switch (theme) {
-        //     case 'dark':
-        //         toggleDarkMode();
-        //         // setIsDarkMode(true);
-        //         // setIsGameboyTheme(false);
-        //         // setIsHomeTheme(false);
-        //         break;
-        //     case 'gameboy':
-        //         toggleGameboyMode();
-        //         // setIsGameboyTheme(true);
-        //         // setIsDarkMode(false);
-        //         // setIsHomeTheme(false);
-        //         break;
-        //     case 'home':
-        //         toggleHomeMode();
-        //         // setIsHomeTheme(true);
-        //         // setIsDarkMode(false);
-        //         // setIsGameboyTheme(false);
-        //         break;
-        //     default:
-        //         toggleDarkMode();
-        //         break;
-        // }
     };
 
     useEffect(() => {
@@ -134,16 +89,6 @@ useEffect(() => {
                 setIsHomeTheme(false);
                 break;
         }
-        // if( {
-        //     setIsDarkMode(JSON.parse(localStorage.getItem('isDarkMode')));
-        // } else if(localStorage.getItem('isGBMode')) {
-        //     setIsGameboyTheme(JSON.parse(localStorage.getItem('isGBMode')));
-        // } else if(localStorage.getItem('isHomeMode')) {
-        //     setIsHomeTheme(JSON.parse(localStorage.getItem('isHomeMode')));
-        // }
-        // if (storedTheme) {
-        //   setIsDarkMode(JSON.parse(storedTheme));
-        // }
       }, []);
 
     const filter = () => {

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -16,11 +16,39 @@ const Home = () => {
     const [generation, setGeneration] = useState('');
     const [gameVersion, setGameVersion] = useState('');
     const [isDarkMode, setIsDarkMode] = useState(false);
+    const [isGameboyTheme, setIsGameboyTheme] = useState(false);
+    const [isHomeTheme, setIsHomeTheme] = useState(false);
 
     const toggleDarkMode = () => {
       const newTheme = !isDarkMode;
-    setIsDarkMode(newTheme);
-    localStorage.setItem('isDarkMode', JSON.stringify(newTheme));
+        setIsDarkMode(newTheme);
+        localStorage.setItem('isDarkMode', JSON.stringify(newTheme));
+    };
+
+    const handleTheme = () => {
+        const theme = document.getElementById('themeSel').value;
+        switch (theme) {
+            case 'dark':
+                setIsDarkMode(true);
+                setIsGameboyTheme(false);
+                setIsHomeTheme(false);
+                break;
+            case 'gameboy':
+                setIsGameboyTheme(true);
+                setIsDarkMode(false);
+                setIsHomeTheme(false);
+                break;
+            case 'home':
+                setIsHomeTheme(true);
+                setIsDarkMode(false);
+                setIsGameboyTheme(false);
+                break;
+            default:
+                setIsHomeTheme(false);
+                setIsDarkMode(false);
+                setIsGameboyTheme(false);
+                break;
+        }
     };
 
     useEffect(() => {
@@ -28,8 +56,24 @@ const Home = () => {
             document.documentElement.classList.add('dark', 'bg-slate-900', 'text-slate-50');
           } else {
             document.documentElement.classList.remove('dark', 'bg-slate-900', 'text-slate-50');
-          }
+          } 
     }, [isDarkMode]);
+
+    useEffect(() => {
+        if (isGameboyTheme) {
+            document.documentElement.classList.add('gb', 'bg-gameboy-bg', 'text-gameboy-bg');
+          } else {
+            document.documentElement.classList.remove('gb', 'bg-gameboy-bg', 'text-gameboy-bg');
+          } 
+    }, [isGameboyTheme]);
+
+    useEffect(() => {
+        if (isHomeTheme) {
+            document.documentElement.classList.add('home', 'bg-gradient-to-r', 'from-home-bg', 'via-home-midbg', 'to-home-endbg',  'text-home-text');
+          } else {
+            document.documentElement.classList.remove('home', 'bg-gradient-to-r', 'from-home-bg', 'via-home-midbg', 'to-home-endbg', 'text-home-text');
+          } 
+    }, [isHomeTheme]);
 
     useEffect(() => {
         fetchPokemons(setPokemons, setLoading, generation);
@@ -51,7 +95,7 @@ const Home = () => {
         <>
             <div
                 className={
-                    `xl:px-24 px-10 mt-8 py-4 sticky top-0 bg-white dark:bg-slate-900 ${openPokemonInfo ? 'xl:pl-10 w-[70%] relative left-[30%]' : ''}`
+                    `xl:px-24 px-10 mt-8 py-4 sticky top-0 dark:bg-slate-900  ${openPokemonInfo ? 'xl:pl-10 w-[70%] relative left-[30%]' : ''}`
                 }>
                 <input
                     value={search}
@@ -61,7 +105,6 @@ const Home = () => {
                     className='outline-none w-full border-2 py-3 px-5 text-lg rounded-full 
                     dark:bg-slate-800 dark:text-slate-50'
                 />
-
                 <div className='flex justify-center flex-col md:flex-row md:justify-end gap-3 mt-3'>
                     <SelectCompoent
                         valueFor={"generation"}
@@ -73,9 +116,12 @@ const Home = () => {
                         value={gameVersion}
                         setValue={setGameVersion}
                     />
-                    <button onClick={toggleDarkMode} className='text-xl mg-5'>
-                        {isDarkMode ? `☀` : `🌕`}
-                    </button> 
+                    <select id="themeSel" onChange={handleTheme} className='outline-none border-2 py-1 px-5 text-md rounded-full cursor-pointer dark:bg-slate-800 dark:text-slate-50'>
+                        <option value="">Light</option>
+                        <option value="dark">Dark</option>
+                        <option value="gameboy">Gameboy</option>
+                        <option value="home">Pokemon Home</option>
+                    </select>
                 </div>
             </div>
 

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -121,12 +121,12 @@ useEffect(() => {
                         value={gameVersion}
                         setValue={setGameVersion}
                     />
-                    <select id="themeSel" onChange={handleTheme} className='outline-none border-2 py-1 px-5 text-md rounded-full cursor-pointer dark:bg-slate-800 dark:text-slate-50'>
-                        <option value="">Light</option>
-                        <option value="dark" selected={theme == "dark"}>Dark</option>
-                        <option value="gameboy" selected={theme == "gameboy"}>Gameboy</option>
-                        <option value="home" selected={theme == "home"}>Pokemon Home</option>
-                    </select>
+                    <SelectCompoent
+                        valueFor={"theme"}
+                        value={theme}
+                        setValue={handleThemeChange}
+                        id={"themeSel"}
+                    />
                 </div>
             </div>
 

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -7,14 +7,40 @@ const PokemonCard = ({ pokemon, setOpenPokemonInfo, setSelectedPokemon }) => {
   }
 
   const [imageLoaded, setImageLoaded] = useState(false)
+  const [pokeArtwork, setPokeArtwork] = useState('other/official-artwork')
+  const [theme, setTheme] = useState(''); // default or gameboy
+
+  useEffect(() => {
+    const themeSel = document.getElementById('themeSel');
+
+    if (themeSel.value === 'gameboy') {
+      setTheme('gameboy');
+    } else if (themeSel.value === 'home') {
+      setTheme('home');
+    } else {
+      setTheme('');
+    }
+  }, []);
+
+
   const ref = useRef(null)
+
+  useEffect(() => {
+    if(document.getElementById('themeSel').value === 'gameboy') {
+      setPokeArtwork('')
+    } else if (document.getElementById('themeSel').value === 'home') {
+      setPokeArtwork('other/home')
+    } else {
+      setPokeArtwork('other/official-artwork')
+    }
+  })
 
   useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => {
         if(entry.isIntersecting) {
           const img = new Image()
-          img.src = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${pokemon.url.split('/')[6]}.png`
+          img.src = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokeArtwork}/${pokemon.url.split('/')[6]}.png`
           img.onload = () => {
             setImageLoaded(true)
           }
@@ -42,19 +68,33 @@ const PokemonCard = ({ pokemon, setOpenPokemonInfo, setSelectedPokemon }) => {
     }
   }, [pokemon])
 
+  const themeSelElement = document.getElementById('themeSel');
+  let pokemonCardDivClass = 'bg-slate-200 border-slate-300';
+  if(themeSelElement && themeSelElement.value === 'gameboy') {
+    pokemonCardDivClass = 'bg-gameboy-border border-gameboy-card';
+  } else if (themeSelElement && themeSelElement.value === 'home') {
+    pokemonCardDivClass = 'bg-home-card shadow-slate-200';
+  } else {
+    pokemonCardDivClass = 'bg-slate-200 border-slate-300';
+  }
+
   return (
     <div
       ref={ref}
-      className={`bg-slate-200 hover:bg-slate-300/30 cursor-pointer flex gap-4 flex-col justify-center p-4 rounded-md shadow-lg border-slate-300 border-2 transition-all transform hover:scale-105 
-      dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700 dark:hover:bg-opacity-30 dark:hover:border-slate-600 dark:text-slate-50`}
+      className={`hover:bg-slate-300/30 cursor-pointer flex gap-4 flex-col justify-center p-4 rounded-md shadow-lg border-2 transition-all transform hover:scale-105 
+      dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700 dark:hover:bg-opacity-30 dark:hover:border-slate-600 dark:text-slate-50 ${pokemonCardDivClass}`}
       onClick={handleClick}
     >
       {imageLoaded ? (
         <div className='w-full h-28 flex items-center justify-center'>
           <img
-            src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${pokemon.url.split('/')[6]}.png`}
+            src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokeArtwork}/${pokemon.url.split('/')[6]}.png`}
             className='h-full'
             alt="image"
+            onError={(e) => {
+              e.target.onerror = null;
+              e.target.src = "/assets/pokeball.png";
+            }}
           />
         </div>
       ) : (

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -8,20 +8,6 @@ const PokemonCard = ({ pokemon, setOpenPokemonInfo, setSelectedPokemon }) => {
 
   const [imageLoaded, setImageLoaded] = useState(false)
   const [pokeArtwork, setPokeArtwork] = useState('other/official-artwork')
-  const [theme, setTheme] = useState(''); // default or gameboy
-
-  useEffect(() => {
-    const themeSel = document.getElementById('themeSel');
-
-    if (themeSel.value === 'gameboy') {
-      setTheme('gameboy');
-    } else if (themeSel.value === 'home') {
-      setTheme('home');
-    } else {
-      setTheme('');
-    }
-  }, []);
-
 
   const ref = useRef(null)
 

--- a/src/components/PokemonInfo.jsx
+++ b/src/components/PokemonInfo.jsx
@@ -7,6 +7,7 @@ const PokemonInfo = ({ selectedPokemon, setInfoOpen }) => {
     const [loadingInfo, setLoadingInfo] = useState(false)
     const [pokemonAbout, setPokemonAbout] = useState('')
     const [pokemonEvolution, setPokemonEvolution] = useState({})
+    const [pokeArtwork, setPokeArtwork] = useState('other/official-artwork')
 
     const id = selectedPokemon.url.replace('https://pokeapi.co/api/v2/pokemon/', '').replace('/', '')
 
@@ -16,12 +17,22 @@ const PokemonInfo = ({ selectedPokemon, setInfoOpen }) => {
         fetchPokemonEvolution(id, setPokemonEvolution)
     }, [selectedPokemon])
 
+    useEffect(() => {
+        if(document.getElementById('themeSel').value === 'gameboy') {
+          setPokeArtwork('')
+        } else {
+          setPokeArtwork('other/official-artwork')
+        }
+      })
+
     // console.log(pokemonInfo)
     console.log(pokemonEvolution)
+    const themeSelElement = document.getElementById('themeSel');
+    const pokemonCardDivClass = themeSelElement && themeSelElement.value === 'gameboy' ? 'bg-gameboy-bg text-slate-200' : 'bg-slate-200';
 
     return !loadingInfo ?
-        <div className='lg:w-[30vw] h-full fixed left-0 top-0 bg-slate-200 shadow-sm shadow-slate-400 px-6 py-6 overflow-y-scroll
-        dark:bg-slate-800 dark:text-slate-50'>
+        <div className={`lg:w-[30vw] h-full fixed left-0 top-0 shadow-sm shadow-slate-400 px-6 py-6 overflow-y-scroll
+        dark:bg-slate-800 dark:text-slate-50 ${pokemonCardDivClass}`}>
             <div
             className='absolute top-5 right-5 bg-slate-400/50 shadow-md h-14 w-14 p-2 rounded-full flex items-center justify-center cursor-pointer hover:bg-slate-500/60 transition-all
             dark:bg-slate-600 dark:hover:bg-slate-500 dark:text-slate-50'
@@ -31,7 +42,7 @@ const PokemonInfo = ({ selectedPokemon, setInfoOpen }) => {
             </div>
             <div className='w-full flex flex-col gap-8 items-center justify-center '>
                 <img
-                    src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${id}.png`}
+                    src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokeArtwork}/${id}.png`}
                     alt="image"
                     className='w-[70%]'
                     onError={(e) => {

--- a/src/components/PokemonInfo.jsx
+++ b/src/components/PokemonInfo.jsx
@@ -20,6 +20,8 @@ const PokemonInfo = ({ selectedPokemon, setInfoOpen }) => {
     useEffect(() => {
         if(document.getElementById('themeSel').value === 'gameboy') {
           setPokeArtwork('')
+        } else if(document.getElementById('themeSel').value === 'home') {
+            setPokeArtwork('other/home')
         } else {
           setPokeArtwork('other/official-artwork')
         }
@@ -28,7 +30,14 @@ const PokemonInfo = ({ selectedPokemon, setInfoOpen }) => {
     // console.log(pokemonInfo)
     console.log(pokemonEvolution)
     const themeSelElement = document.getElementById('themeSel');
-    const pokemonCardDivClass = themeSelElement && themeSelElement.value === 'gameboy' ? 'bg-gameboy-bg text-slate-200' : 'bg-slate-200';
+    let pokemonCardDivClass = 'bg-slate-200 border-slate-300';
+    if(themeSelElement && themeSelElement.value === 'gameboy') {
+      pokemonCardDivClass = 'bg-gameboy-bg text-slate-200';
+    } else if (themeSelElement && themeSelElement.value === 'home') {
+      pokemonCardDivClass = 'bg-home-card shadow-slate-200';
+    } else {
+      pokemonCardDivClass = 'bg-slate-200 border-slate-300';
+    }
 
     return !loadingInfo ?
         <div className={`lg:w-[30vw] h-full fixed left-0 top-0 shadow-sm shadow-slate-400 px-6 py-6 overflow-y-scroll

--- a/src/components/SelectCompoent.jsx
+++ b/src/components/SelectCompoent.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-const SelectCompoent = ({ valueFor, value, setValue }) => {
+const SelectCompoent = ({ valueFor, value, setValue, id = null }) => {
     const [selectOptionClicked, setSelectOptionClicked] = useState(false);
 
     const handleSelectChange = (e) => {
@@ -14,6 +14,7 @@ const SelectCompoent = ({ valueFor, value, setValue }) => {
         <select
             value={value}
             onChange={(e) => handleSelectChange(e)}
+            id={id}
             // className={`outline-none border-2 py-1 px-5 text-md rounded-full cursor-pointer ${selectOptionClicked && 'bg-red-400'}`}
             className={`outline-none border-2 py-1 px-5 text-md rounded-full cursor-pointer dark:bg-slate-800 dark:text-slate-50`}
         >
@@ -31,7 +32,7 @@ const SelectCompoent = ({ valueFor, value, setValue }) => {
                         <option value="809,96">Generation 8</option>
                         <option value="905,112">Generation 9</option>
                     </>
-                    : valueFor === "gameVersion" &&
+                    : valueFor === "gameVersion" ?
                     <>
                         <option value="">All Versions</option>
                         <option value="red">Red</option>
@@ -69,6 +70,13 @@ const SelectCompoent = ({ valueFor, value, setValue }) => {
                         <option value="legends-arceus">Legends Arceus</option>
                         <option value="scarlet">Scarlet</option>
                         <option value="violet">Violet</option>
+                    </>
+                    : valueFor === "theme" &&
+                    <>
+                        <option value="">Light</option>
+                        <option value="dark" selected={value == "dark"}>Dark</option>
+                        <option value="gameboy" selected={value == "gameboy"}>Gameboy</option>
+                        <option value="home" selected={value == "home"}>Pokemon Home</option>
                     </>
             }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,32 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  darkMode: 'class',
-  content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+  darkMode: "class",
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        // Define Gameboy-style colors
+        // Example:
+        'gameboy-bg': "#0f380f",
+        'gameboy-text': "#8bac0f",
+        'gameboy-card': "#306230",
+        'gameboy-border': "#9bbc0f",
+        'home-bg': '#9CE7CC',
+        'home-midbg': '#D4F699',
+        'home-endbg': '#5EFC9C',
+        'home-text': '#000',
+        'home-card': '#D6C6F8',
+        'home-border': '#9bbc0f',
+      },
+    },
+    plugins: [
+      function ({ addVariant, e }) {
+        addVariant("gb", ({ modifySelectors, separator }) => {
+          modifySelectors(({ className }) => {
+            return `.gb${separator}${className}`;
+          });
+        });
+      },
+    ],
   },
-  plugins: [],
-}
+};


### PR DESCRIPTION
@TheShiveshNetwork 

Fixes #22 

Updates:
- Added new custom themes: Gameboy & Pokemon Home
- Gameboy utilizes the limited colour scheme of the original Gameboy and utilizes sprites instead of official art for all 1017 Pokemon
- Pokemon Home is based on the colours used in the app reference pictures can be found below
- Made both themes storable
- Updated the way tracking themes is handled to support any number of additional themes
- Added a drop-down for the themes
- Updated `SelectComponents.jsx` to support ids for tracking the theme changes (default is `null`).

I had a lot of fun with this, I hope all the changes are up to spec! Here are some pictures of the themes in action:

## Gameboy: 
![gameboy home](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/94a403cf-a663-42a6-afd4-e66d53f723b5)
![gameboy info](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/d8196bfd-d813-4c6e-a782-0594ffd6fe0d)

## Pokemon Home:
![home home](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/35078e50-ad11-4a3a-9fe6-03cd840fdac8)
![home info](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/ce72eff9-545d-4154-8c28-36ba39e85808)

## References for the home theme:
![home ref](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/63c87e9b-b19c-4a90-8f27-ea7918ce503b)
![home ref 2](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/aa9f038d-2cfc-4ddf-acc3-e38da8bd1cd1)
> taken from the [official Nintendo store page](https://www.nintendo.com/us/store/products/pokemon-home-switch/)

Of course, feel free to request changes, I will add them ASAP!