### PR TITLE
Feature: ReAdded Custom themes

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -16,29 +16,73 @@ const Home = () => {
     const [generation, setGeneration] = useState('');
     const [gameVersion, setGameVersion] = useState('');
     const [isDarkMode, setIsDarkMode] = useState(false);
-
-    const toggleDarkMode = () => {
-      const newTheme = !isDarkMode;
-    setIsDarkMode(newTheme);
-    localStorage.setItem('isDarkMode', JSON.stringify(newTheme));
-    };
+    const [isGameboyTheme, setIsGameboyTheme] = useState(false);
+    const [isHomeTheme, setIsHomeTheme] = useState(false);
+    const [theme, setTheme] = useState('');
 
     useEffect(() => {
-        if (isDarkMode) {
-            document.documentElement.classList.add('dark', 'bg-slate-900', 'text-slate-50');
-          } else {
-            document.documentElement.classList.remove('dark', 'bg-slate-900', 'text-slate-50');
-          }
-    }, [isDarkMode]);
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme !== null) {
+            setTheme(savedTheme);
+        }
+    }, []);
+
+    const handleThemeChange = (newTheme) => {
+        setTheme(newTheme);
+        localStorage.setItem('theme', newTheme);
+    };
+
+useEffect(() => {
+    if (theme === 'dark') {
+        document.documentElement.classList.add('dark', 'bg-slate-900', 'text-slate-50');
+    } else {
+        document.documentElement.classList.remove('dark', 'bg-slate-900', 'text-slate-50');
+    } 
+}, [theme]);
+
+useEffect(() => {
+    if (theme === 'gameboy') {
+        document.documentElement.classList.add('gb', 'bg-gameboy-bg', 'text-gameboy-bg');
+    } else {
+        document.documentElement.classList.remove('gb', 'bg-gameboy-bg', 'text-gameboy-bg');
+    } 
+}, [theme]);
+
+useEffect(() => {
+    if (theme === 'home') {
+        document.documentElement.classList.add('home', 'bg-gradient-to-r', 'from-home-bg', 'via-home-midbg', 'to-home-endbg',  'text-home-text');
+    } else {
+        document.documentElement.classList.remove('home', 'bg-gradient-to-r', 'from-home-bg', 'via-home-midbg', 'to-home-endbg', 'text-home-text');
+    } 
+}, [theme]);
 
     useEffect(() => {
         fetchPokemons(setPokemons, setLoading, generation);
     }, [generation]);
 
     useEffect(() => {
-        const storedTheme = localStorage.getItem('isDarkMode');
-        if (storedTheme) {
-          setIsDarkMode(JSON.parse(storedTheme));
+        const storedTheme = localStorage.getItem('theme');
+        switch (storedTheme) {
+            case 'dark':
+                setIsDarkMode(true);
+                setIsGameboyTheme(false);
+                setIsHomeTheme(false);
+                break;
+            case 'gameboy':
+                setIsGameboyTheme(true);
+                setIsDarkMode(false);
+                setIsHomeTheme(false);
+                break;
+            case 'home':
+                setIsHomeTheme(true);
+                setIsDarkMode(false);
+                setIsGameboyTheme(false);
+                break;
+            default:
+                setIsDarkMode(false);
+                setIsGameboyTheme(false);
+                setIsHomeTheme(false);
+                break;
         }
       }, []);
 
@@ -49,10 +93,10 @@ const Home = () => {
 
     return !loading ?
         <>
-            <div
-                className={
-                    `xl:px-24 px-10 mt-8 py-4 sticky top-0 bg-white dark:bg-slate-900 ${openPokemonInfo ? 'xl:pl-10 w-[70%] relative left-[30%]' : ''} z-[99999]`
-                }>
+<div
+    className={
+        `xl:px-24 px-10 mt-8 py-4 sticky top-0 dark:bg-slate-900  ${openPokemonInfo ? 'xl:pl-10 w-[70%] relative left-[30%]' : ''}`
+    }>
                 <input
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
@@ -61,7 +105,6 @@ const Home = () => {
                     className='outline-none w-full border-2 py-3 px-5 text-lg rounded-full 
                     dark:bg-slate-800 dark:text-slate-50'
                 />
-
                 <div className='flex justify-center flex-col md:flex-row md:justify-end gap-3 mt-3'>
                     <SelectCompoent
                         valueFor={"generation"}
@@ -73,9 +116,12 @@ const Home = () => {
                         value={gameVersion}
                         setValue={setGameVersion}
                     />
-                    <button onClick={toggleDarkMode} className='text-xl mg-5'>
-                        {isDarkMode ? `☀` : `🌕`}
-                    </button> 
+                    <SelectCompoent
+                        valueFor={"theme"}
+                        value={theme}
+                        setValue={handleThemeChange}
+                        id={"themeSel"}
+                    />
                 </div>
             </div>
 

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -8,6 +8,7 @@ const PokemonCard = ({ pokemon, setOpenPokemonInfo, setSelectedPokemon }) => {
 
   const [imageLoaded, setImageLoaded] = useState(false)
   const [pokeArtwork, setPokeArtwork] = useState('other/official-artwork')
+  const [theme, setTheme] = useState('')
   const ref = useRef(null)
 
   useEffect(() => {
@@ -43,17 +44,15 @@ const PokemonCard = ({ pokemon, setOpenPokemonInfo, setSelectedPokemon }) => {
     }
   }, [pokemon, pokeArtwork])
 
-  const themeSelValue = document.getElementById('themeSel').value;
-
   useEffect(() => {
-    if(themeSelValue === 'gameboy') {
+    if(document.getElementById('themeSel').value === 'gameboy') {
       setPokeArtwork('')
-    } else if (themeSelValue === 'home') {
+    } else if (document.getElementById('themeSel').value === 'home') {
       setPokeArtwork('other/home')
     } else {
       setPokeArtwork('other/official-artwork')
     }
-  }, [themeSelValue])
+  })
 
   const themeSelElement = document.getElementById('themeSel');
   let pokemonCardDivClass = 'bg-slate-200 border-slate-300';

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -7,6 +7,7 @@ const PokemonCard = ({ pokemon, setOpenPokemonInfo, setSelectedPokemon }) => {
   }
 
   const [imageLoaded, setImageLoaded] = useState(false)
+  const [pokeArtwork, setPokeArtwork] = useState('other/official-artwork')
   const ref = useRef(null)
 
   useEffect(() => {
@@ -14,7 +15,7 @@ const PokemonCard = ({ pokemon, setOpenPokemonInfo, setSelectedPokemon }) => {
       ([entry]) => {
         if(entry.isIntersecting) {
           const img = new Image()
-          img.src = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${pokemon.url.split('/')[6]}.png`
+          img.src = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokeArtwork}/${pokemon.url.split('/')[6]}.png`
           img.onload = () => {
             setImageLoaded(true)
           }
@@ -40,21 +41,47 @@ const PokemonCard = ({ pokemon, setOpenPokemonInfo, setSelectedPokemon }) => {
         }
       }
     }
-  }, [pokemon])
+  }, [pokemon, pokeArtwork])
+
+  const themeSelValue = document.getElementById('themeSel').value;
+
+  useEffect(() => {
+    if(themeSelValue === 'gameboy') {
+      setPokeArtwork('')
+    } else if (themeSelValue === 'home') {
+      setPokeArtwork('other/home')
+    } else {
+      setPokeArtwork('other/official-artwork')
+    }
+  }, [themeSelValue])
+
+  const themeSelElement = document.getElementById('themeSel');
+  let pokemonCardDivClass = 'bg-slate-200 border-slate-300';
+  if(themeSelElement && themeSelElement.value === 'gameboy') {
+    pokemonCardDivClass = 'bg-gameboy-border border-gameboy-card';
+  } else if (themeSelElement && themeSelElement.value === 'home') {
+    pokemonCardDivClass = 'bg-home-card shadow-slate-200';
+  } else {
+    pokemonCardDivClass = 'bg-slate-200 border-slate-300';
+  }
 
   return (
     <div
       ref={ref}
-      className={`bg-slate-200 hover:bg-slate-300/30 cursor-pointer flex gap-4 flex-col justify-center p-4 rounded-md shadow-lg border-slate-300 border-2 transition-all transform hover:scale-105 
-      dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700 dark:hover:bg-opacity-30 dark:hover:border-slate-600 dark:text-slate-50`}
+      className={`hover:bg-slate-300/30 cursor-pointer flex gap-4 flex-col justify-center p-4 rounded-md shadow-lg border-2 transition-all transform hover:scale-105 
+      dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700 dark:hover:bg-opacity-30 dark:hover:border-slate-600 dark:text-slate-50 ${pokemonCardDivClass}`}
       onClick={handleClick}
     >
       {imageLoaded ? (
         <div className='w-full h-28 flex items-center justify-center'>
           <img
-            src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${pokemon.url.split('/')[6]}.png`}
+            src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokeArtwork}/${pokemon.url.split('/')[6]}.png`}
             className='h-full'
             alt="image"
+            onError={(e) => {
+              e.target.onerror = null;
+              e.target.src = "/assets/pokeball.png";
+            }}
           />
         </div>
       ) : (

--- a/src/components/PokemonInfo.jsx
+++ b/src/components/PokemonInfo.jsx
@@ -7,6 +7,7 @@ const PokemonInfo = ({ selectedPokemon, setInfoOpen }) => {
     const [loadingInfo, setLoadingInfo] = useState(false)
     const [pokemonAbout, setPokemonAbout] = useState('')
     const [pokemonEvolution, setPokemonEvolution] = useState({})
+    const [pokeArtwork, setPokeArtwork] = useState('other/official-artwork')
 
     const id = selectedPokemon.url.replace('https://pokeapi.co/api/v2/pokemon/', '').replace('/', '')
 
@@ -16,12 +17,34 @@ const PokemonInfo = ({ selectedPokemon, setInfoOpen }) => {
         fetchPokemonEvolution(id, setPokemonEvolution)
     }, [selectedPokemon])
 
+    const themeSelValue = document.getElementById('themeSel').value;
+
+    useEffect(() => {
+      if(themeSelValue === 'gameboy') {
+        setPokeArtwork('')
+      } else if (themeSelValue === 'home') {
+        setPokeArtwork('other/home')
+      } else {
+        setPokeArtwork('other/official-artwork')
+      }
+    }, [themeSelValue])
+
+    const themeSelElement = document.getElementById('themeSel');
+    let pokemonCardDivClass = 'bg-slate-200 border-slate-300';
+    if(themeSelElement && themeSelElement.value === 'gameboy') {
+      pokemonCardDivClass = 'bg-gameboy-bg text-slate-200';
+    } else if (themeSelElement && themeSelElement.value === 'home') {
+      pokemonCardDivClass = 'bg-home-card shadow-slate-200';
+    } else {
+      pokemonCardDivClass = 'bg-slate-200 border-slate-300';
+    }
+
     // console.log(pokemonInfo)
     console.log(pokemonEvolution)
 
     return !loadingInfo ?
-        <div className='lg:w-[30vw] h-full fixed left-0 top-0 bg-slate-200 shadow-sm shadow-slate-400 px-6 py-6 overflow-y-scroll
-        dark:bg-slate-800 dark:text-slate-50'>
+        <div className={`lg:w-[30vw] h-full fixed left-0 top-0 shadow-sm shadow-slate-400 px-6 py-6 overflow-y-scroll
+        dark:bg-slate-800 dark:text-slate-50 ${pokemonCardDivClass}`}>
             <div
             className='absolute top-5 right-5 bg-slate-400/50 shadow-md h-14 w-14 p-2 rounded-full flex items-center justify-center cursor-pointer hover:bg-slate-500/60 transition-all
             dark:bg-slate-600 dark:hover:bg-slate-500 dark:text-slate-50'
@@ -31,7 +54,7 @@ const PokemonInfo = ({ selectedPokemon, setInfoOpen }) => {
             </div>
             <div className='w-full flex flex-col gap-8 items-center justify-center '>
                 <img
-                    src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${id}.png`}
+                    src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokeArtwork}/${id}.png`}
                     alt="image"
                     className='w-[70%]'
                     onError={(e) => {

--- a/src/components/PokemonInfo.jsx
+++ b/src/components/PokemonInfo.jsx
@@ -17,17 +17,16 @@ const PokemonInfo = ({ selectedPokemon, setInfoOpen }) => {
         fetchPokemonEvolution(id, setPokemonEvolution)
     }, [selectedPokemon])
 
-    const themeSelValue = document.getElementById('themeSel').value;
 
     useEffect(() => {
-      if(themeSelValue === 'gameboy') {
-        setPokeArtwork('')
-      } else if (themeSelValue === 'home') {
-        setPokeArtwork('other/home')
-      } else {
-        setPokeArtwork('other/official-artwork')
-      }
-    }, [themeSelValue])
+        if(document.getElementById('themeSel').value === 'gameboy') {
+          setPokeArtwork('')
+        } else if (document.getElementById('themeSel').value === 'home') {
+          setPokeArtwork('other/home')
+        } else {
+          setPokeArtwork('other/official-artwork')
+        }
+    })
 
     const themeSelElement = document.getElementById('themeSel');
     let pokemonCardDivClass = 'bg-slate-200 border-slate-300';

--- a/src/components/SelectCompoent.jsx
+++ b/src/components/SelectCompoent.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-const SelectCompoent = ({ valueFor, value, setValue }) => {
+const SelectCompoent = ({ valueFor, value, setValue, id = null }) => {
     const [selectOptionClicked, setSelectOptionClicked] = useState(false);
 
     const handleSelectChange = (e) => {
@@ -14,6 +14,7 @@ const SelectCompoent = ({ valueFor, value, setValue }) => {
         <select
             value={value}
             onChange={(e) => handleSelectChange(e)}
+            id={id}
             // className={`outline-none border-2 py-1 px-5 text-md rounded-full cursor-pointer ${selectOptionClicked && 'bg-red-400'}`}
             className={`outline-none border-2 py-1 px-5 text-md rounded-full cursor-pointer dark:bg-slate-800 dark:text-slate-50`}
         >
@@ -31,7 +32,7 @@ const SelectCompoent = ({ valueFor, value, setValue }) => {
                         <option value="809,96">Generation 8</option>
                         <option value="905,112">Generation 9</option>
                     </>
-                    : valueFor === "gameVersion" &&
+                    : valueFor === "gameVersion" ?
                     <>
                         <option value="">All Versions</option>
                         <option value="red">Red</option>
@@ -69,6 +70,13 @@ const SelectCompoent = ({ valueFor, value, setValue }) => {
                         <option value="legends-arceus">Legends Arceus</option>
                         <option value="scarlet">Scarlet</option>
                         <option value="violet">Violet</option>
+                    </>
+                    : valueFor === "theme" &&
+                    <>
+                        <option value="">Light</option>
+                        <option value="dark" selected={value == "dark"}>Dark</option>
+                        <option value="gameboy" selected={value == "gameboy"}>Gameboy</option>
+                        <option value="home" selected={value == "home"}>Pokemon Home</option>
                     </>
             }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,33 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  darkMode: 'class',
-  content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+  darkMode: "class",
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        // Define Gameboy-style colors
+        // Example:
+        'gameboy-bg': "#0f380f",
+        'gameboy-text': "#8bac0f",
+        'gameboy-card': "#306230",
+        'gameboy-border': "#9bbc0f",
+        'home-bg': '#9CE7CC',
+        'home-midbg': '#D4F699',
+        'home-endbg': '#5EFC9C',
+        'home-text': '#000',
+        'home-card': '#D6C6F8',
+        'home-border': '#9bbc0f',
+      },
+    },
+    plugins: [
+      function ({ addVariant, e }) {
+        addVariant("gb", ({ modifySelectors, separator }) => {
+          modifySelectors(({ className }) => {
+            return `.gb${separator}${className}`;
+          });
+        });
+      },
+    ],
   },
   plugins: [],
 }


### PR DESCRIPTION
@TheShiveshNetwork 

Fixes #22 

Created a new PR as requested in #26 

Updates:
- Added new custom themes: Gameboy & Pokemon Home
- Gameboy utilizes the limited colour scheme of the original Gameboy and utilizes sprites instead of official art for all 1017 Pokemon
- Pokemon Home is based on the colours used in the app reference pictures can be found below
- Made both themes storable
- Updated the way tracking themes is handled to support any number of additional themes
- Added a drop-down for the themes
- Updated `SelectComponents.jsx` to support ids for tracking the theme changes (default is `null`).

I had a lot of fun with this, I hope all the changes are up to spec! Here are some pictures of the themes in action:

## Gameboy: 
![gameboy home](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/94a403cf-a663-42a6-afd4-e66d53f723b5)
![gameboy info](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/d8196bfd-d813-4c6e-a782-0594ffd6fe0d)

## Pokemon Home:
![home home](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/35078e50-ad11-4a3a-9fe6-03cd840fdac8)
![home info](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/ce72eff9-545d-4154-8c28-36ba39e85808)

## References for the home theme:
![home ref](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/63c87e9b-b19c-4a90-8f27-ea7918ce503b)
![home ref 2](https://github.com/TheShiveshNetwork/Pokedex/assets/55001591/aa9f038d-2cfc-4ddf-acc3-e38da8bd1cd1)
> taken from the [official Nintendo store page](https://www.nintendo.com/us/store/products/pokemon-home-switch/)

Of course, feel free to request changes, I will add them ASAP!



























